### PR TITLE
Remove LibreOfficeKit from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,6 @@ urlencode.o: urlencode.cc \
 	$(CXX) -I. -c -W -Wall -O2 -g urlencode.cc -o urlencode.o
 
 convert.o: convert.cc \
-    LibreOfficeKit/LibreOfficeKit.h \
-    LibreOfficeKit/LibreOfficeKit.hxx \
-    LibreOfficeKit/LibreOfficeKitInit.h \
-    LibreOfficeKit/LibreOfficeKitTypes.h \
     convert.h \
     urlencode.h
 	$(CXX) -I. -c -W -Wall -O2 -g convert.cc -o convert.o


### PR DESCRIPTION
Since LibreOfficeKit is now pulled in as a system library and has been removed from the repository, it can't be referenced from the Makefile anymore.

Otherwise `make` fails with ``` *** No rule to make target `LibreOfficeKit/LibreOfficeKit.h', needed by `convert.o'.  Stop.```
