### PR TITLE
Use standard format to improve readability

### DIFF
--- a/convert.cc
+++ b/convert.cc
@@ -13,10 +13,10 @@
 #include <exception>
 #include <iostream>
 
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+#include <sys/types.h>
 #include <sysexits.h>
+#include <unistd.h>
 
 #include <LibreOfficeKit/LibreOfficeKit.hxx>
 
@@ -29,98 +29,99 @@ using namespace lok;
 #define LO_PATH_DEBIAN "/usr/lib/libreoffice/program"
 
 // Install location for .deb files from libreoffice.org:
-#define LO_PATH_LIBREOFFICEORG(V) "/opt/libreoffice"#V"/program"
+#define LO_PATH_LIBREOFFICEORG(V) "/opt/libreoffice" #V "/program"
 
-const char * program = "<program>";
+const char *program = "<program>";
 
 // Find a LibreOffice installation to use.
-static const char *
-get_lo_path()
-{
-    const char * lo_path = getenv("LO_PATH");
+static const char *get_lo_path() {
+  const char *lo_path = getenv("LO_PATH");
+  if (!lo_path) {
+    struct stat sb;
+#define CHECK_DIR(P)                                                           \
+  if (!lo_path && stat(P "/versionrc", &sb) == 0 && S_ISREG(sb.st_mode))       \
+  lo_path = P
+    CHECK_DIR(LO_PATH_DEBIAN);
+    CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.4));
+    CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.3));
+    CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.2));
+    CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.1));
+    CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.0));
+    CHECK_DIR(LO_PATH_LIBREOFFICEORG(4.4));
+    CHECK_DIR(LO_PATH_LIBREOFFICEORG(4.3));
+
     if (!lo_path) {
-	struct stat sb;
-#define CHECK_DIR(P) if (!lo_path && stat(P"/versionrc", &sb) == 0 && S_ISREG(sb.st_mode)) lo_path = P
-	CHECK_DIR(LO_PATH_DEBIAN);
-	CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.4));
-	CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.3));
-	CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.2));
-	CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.1));
-	CHECK_DIR(LO_PATH_LIBREOFFICEORG(5.0));
-	CHECK_DIR(LO_PATH_LIBREOFFICEORG(4.4));
-	CHECK_DIR(LO_PATH_LIBREOFFICEORG(4.3));
-
-	if (!lo_path) {
-	    cerr << program << ": LibreOffice install not found\n"
-		"Set LO_PATH in the environment to the 'program' directory - e.g.:\n"
-		"LO_PATH=/opt/libreoffice/program\n"
-		"export LO_PATH" << endl;
-	    _Exit(1);
-	}
+      cerr << program
+           << ": LibreOffice install not found\n"
+              "Set LO_PATH in the environment to the 'program' directory - "
+              "e.g.:\n"
+              "LO_PATH=/opt/libreoffice/program\n"
+              "export LO_PATH"
+           << endl;
+      _Exit(1);
     }
-    return lo_path;
+  }
+  return lo_path;
 }
 
-void *
-convert_init()
-{
-    Office * llo = NULL;
-    try {
-	const char * lo_path = get_lo_path();
-	llo = lok_cpp_init(lo_path);
-	if (!llo) {
-	    cerr << program << ": Failed to initialise LibreOfficeKit" << endl;
-	    return NULL;
-	}
-	return static_cast<void*>(llo);
-    } catch (const exception & e) {
-	delete llo;
-	cerr << program << ": LibreOfficeKit threw exception (" << e.what() << ")" << endl;
-	return NULL;
+void *convert_init() {
+  Office *llo = NULL;
+  try {
+    const char *lo_path = get_lo_path();
+    llo = lok_cpp_init(lo_path);
+    if (!llo) {
+      cerr << program << ": Failed to initialise LibreOfficeKit" << endl;
+      return NULL;
     }
-}
-
-void
-convert_cleanup(void * h_void)
-{
-    Office * llo = static_cast<Office *>(h_void);
+    return static_cast<void *>(llo);
+  } catch (const exception &e) {
     delete llo;
+    cerr << program << ": LibreOfficeKit threw exception (" << e.what() << ")"
+         << endl;
+    return NULL;
+  }
 }
 
-int
-convert(void * h_void, bool url,
-	const char * input, const char * output,
-	const char * format, const char * options)
-try {
-    if (!h_void) return 1;
-    Office * llo = static_cast<Office *>(h_void);
+void convert_cleanup(void *h_void) {
+  Office *llo = static_cast<Office *>(h_void);
+  delete llo;
+}
 
-    string input_url;
-    if (url) {
-	input_url = input;
-    } else {
-	url_encode_path(input_url, input);
-    }
-    Document * lodoc = llo->documentLoad(input_url.c_str(), options);
-    if (!lodoc) {
-	const char * errmsg = llo->getError();
-	cerr << program << ": LibreOfficeKit failed to load document (" << errmsg << ")" << endl;
-	return 1;
-    }
-
-    string output_url;
-    url_encode_path(output_url, output);
-    if (!lodoc->saveAs(output_url.c_str(), format, options)) {
-	const char * errmsg = llo->getError();
-	cerr << program << ": LibreOfficeKit failed to export (" << errmsg << ")" << endl;
-	delete lodoc;
-	return 1;
-    }
-
-    delete lodoc;
-
-    return 0;
-} catch (const exception & e) {
-    cerr << program << ": LibreOfficeKit threw exception (" << e.what() << ")" << endl;
+int convert(void *h_void, bool url, const char *input, const char *output,
+            const char *format, const char *options) try {
+  if (!h_void)
     return 1;
+  Office *llo = static_cast<Office *>(h_void);
+
+  string input_url;
+  if (url) {
+    input_url = input;
+  } else {
+    url_encode_path(input_url, input);
+  }
+  Document *lodoc = llo->documentLoad(input_url.c_str(), options);
+  if (!lodoc) {
+    const char *errmsg = llo->getError();
+    cerr << program << ": LibreOfficeKit failed to load document (" << errmsg
+         << ")" << endl;
+    return 1;
+  }
+
+  string output_url;
+  url_encode_path(output_url, output);
+  if (!lodoc->saveAs(output_url.c_str(), format, options)) {
+    const char *errmsg = llo->getError();
+    cerr << program << ": LibreOfficeKit failed to export (" << errmsg << ")"
+         << endl;
+    delete lodoc;
+    return 1;
+  }
+
+  delete lodoc;
+
+  return 0;
+} catch (const exception &e) {
+  cerr << program << ": LibreOfficeKit threw exception (" << e.what() << ")"
+       << endl;
+  return 1;
 }

--- a/convert.h
+++ b/convert.h
@@ -10,12 +10,11 @@
 #ifndef INCLUDED_CONVERT_H
 #define INCLUDED_CONVERT_H
 
-extern const char * program;
+extern const char *program;
 
-void * convert_init();
-int convert(void * h_void, bool url,
-	    const char * input, const char * output,
-	    const char * format = 0, const char * options = 0);
-void convert_cleanup(void * h_void);
+void *convert_init();
+int convert(void *h_void, bool url, const char *input, const char *output,
+            const char *format = 0, const char *options = 0);
+void convert_cleanup(void *h_void);
 
 #endif

--- a/inject-meta.cc
+++ b/inject-meta.cc
@@ -29,191 +29,193 @@ using namespace std;
 // replaced.
 #define TEMP_DIR_TEMPLATE "/inject-meta-XXXXXX"
 
-static void
-usage()
-{
-    cerr << "Usage: " << program << " -mNAME=VALUE[...] INPUT_FILE OUTPUT_FILE\n\n";
-    cerr << flush;
+static void usage() {
+  cerr << "Usage: " << program
+       << " -mNAME=VALUE[...] INPUT_FILE OUTPUT_FILE\n\n";
+  cerr << flush;
 }
 
-static void
-write_xml_tag(FILE * out, const char * tag, const char * content)
-{
-    fprintf(out, "<%s>", tag);
-    for (const char * p = content; *p; ++p) {
-	switch (*p) {
-	    case '&':
-		fputs("&amp;", out);
-		break;
-	    case '<':
-		fputs("&lt;", out);
-		break;
-	    case '>':
-		fputs("&gt;", out);
-		break;
-	    default:
-		putc(*p, out);
-		break;
-	}
+static void write_xml_tag(FILE *out, const char *tag, const char *content) {
+  fprintf(out, "<%s>", tag);
+  for (const char *p = content; *p; ++p) {
+    switch (*p) {
+    case '&':
+      fputs("&amp;", out);
+      break;
+    case '<':
+      fputs("&lt;", out);
+      break;
+    case '>':
+      fputs("&gt;", out);
+      break;
+    default:
+      putc(*p, out);
+      break;
     }
-    fprintf(out, "</%s>", tag);
+  }
+  fprintf(out, "</%s>", tag);
 }
 
-int
-main(int argc, char **argv)
-{
-    program = argv[0];
+int main(int argc, char **argv) {
+  program = argv[0];
 
-    if (argc < 3) {
-	usage();
-	_Exit(EX_USAGE);
+  if (argc < 3) {
+    usage();
+    _Exit(EX_USAGE);
+  }
+
+  map<string, const char *> meta;
+
+  // FIXME: Use getopt() or something.
+  while (argv[1][0] == '-') {
+    switch (argv[1][1]) {
+    case '-':
+      if (argv[1][2] == '\0') {
+        // End of options.
+        ++argv;
+        --argc;
+        goto last_option;
+      }
+      break;
+    case 'm': {
+      const char *tag = argv[1] + 2;
+      const char *eq = strchr(tag, '=');
+      if (!eq) {
+        cerr << "Option '" << argv[1] << "' missing '='\n\n";
+        usage();
+        _Exit(EX_USAGE);
+      }
+      meta[string(tag, eq - tag)] = eq + 1;
+      ++argv;
+      --argc;
+      continue;
+    }
     }
 
-    map<string, const char *> meta;
-
-    // FIXME: Use getopt() or something.
-    while (argv[1][0] == '-') {
-	switch (argv[1][1]) {
-	    case '-':
-		if (argv[1][2] == '\0') {
-		    // End of options.
-		    ++argv;
-		    --argc;
-		    goto last_option;
-		}
-		break;
-	    case 'm': {
-		const char * tag = argv[1] + 2;
-		const char * eq = strchr(tag, '=');
-		if (!eq) {
-		    cerr << "Option '" << argv[1] << "' missing '='\n\n";
-		    usage();
-		    _Exit(EX_USAGE);
-		}
-		meta[string(tag, eq - tag)] = eq + 1;
-		++argv;
-		--argc;
-		continue;
-	    }
-	}
-
-	cerr << "Option '" << argv[1] << "' unknown\n\n";
-	argc = 0;
-	break;
-    }
+    cerr << "Option '" << argv[1] << "' unknown\n\n";
+    argc = 0;
+    break;
+  }
 last_option:
 
-    if (argc != 3) {
-	usage();
-	_Exit(EX_USAGE);
+  if (argc != 3) {
+    usage();
+    _Exit(EX_USAGE);
+  }
+
+  const char *input = argv[1];
+  const char *output = argv[2];
+
+  void *handle = convert_init();
+
+  // Create a temporary directory.
+  const char *p = getenv("TMPDIR");
+  if (!p)
+    p = "/tmp";
+  char *dir_template = new char[sizeof(TEMP_DIR_TEMPLATE) + strlen(p)];
+  strcpy(dir_template, p);
+  strcat(dir_template, TEMP_DIR_TEMPLATE);
+  p = mkdtemp(dir_template);
+  if (!p) {
+    cerr << program << ": mkdtemp() failed (" << strerror(errno) << ")" << endl;
+    _Exit(1);
+  }
+  string tmpdir(p);
+
+  string odt = tmpdir + "/tmp.odt";
+  int rc = convert(handle, false, input, odt.c_str());
+
+  if (!rc) {
+    int cwd_fd = open(".", O_RDONLY);
+    if (cwd_fd < 0) {
+      cerr << program << ": open(\".\") failed (" << strerror(errno) << ")"
+           << endl;
+      _Exit(1);
+    }
+    if (chdir(tmpdir.c_str()) < 0) {
+      cerr << program << ": chdir() failed (" << strerror(errno) << ")" << endl;
+      _Exit(1);
+    }
+    FILE *f = popen("unzip -p tmp.odt meta.xml", "r");
+    if (!f) {
+      cerr << program << ": popen() failed (" << strerror(errno) << ")" << endl;
+      _Exit(1);
     }
 
-    const char * input = argv[1];
-    const char * output = argv[2];
-
-    void * handle = convert_init();
-
-    // Create a temporary directory.
-    const char * p = getenv("TMPDIR");
-    if (!p) p = "/tmp";
-    char * dir_template = new char[sizeof(TEMP_DIR_TEMPLATE) + strlen(p)];
-    strcpy(dir_template, p);
-    strcat(dir_template, TEMP_DIR_TEMPLATE);
-    p = mkdtemp(dir_template);
-    if (!p) {
-	cerr << program << ": mkdtemp() failed (" << strerror(errno) << ")" << endl;
-	_Exit(1);
+    FILE *out = fopen("meta.xml", "w");
+    if (!out) {
+      cerr << program << ": fopen() failed (" << strerror(errno) << ")" << endl;
+      _Exit(1);
     }
-    string tmpdir(p);
 
-    string odt = tmpdir + "/tmp.odt";
-    int rc = convert(handle, false, input, odt.c_str());
+    char *line = NULL;
+    size_t len = 0;
+    ssize_t c;
 
-    if (!rc) {
-	int cwd_fd = open(".", O_RDONLY);
-	if (cwd_fd < 0) {
-	    cerr << program << ": open(\".\") failed (" << strerror(errno) << ")" << endl;
-	    _Exit(1);
-	}
-	if (chdir(tmpdir.c_str()) < 0) {
-	    cerr << program << ": chdir() failed (" << strerror(errno) << ")" << endl;
-	    _Exit(1);
-	}
-	FILE * f = popen("unzip -p tmp.odt meta.xml", "r");
-	if (!f) {
-	    cerr << program << ": popen() failed (" << strerror(errno) << ")" << endl;
-	    _Exit(1);
-	}
-
-	FILE * out = fopen("meta.xml", "w");
-	if (!out) {
-	    cerr << program << ": fopen() failed (" << strerror(errno) << ")" << endl;
-	    _Exit(1);
-	}
-
-	char *line = NULL;
-	size_t len = 0;
-	ssize_t c;
-
-	bool in_meta = false;
-	while ((c = getdelim(&line, &len, '>', f)) != -1) {
-	    if (in_meta) {
-		if (strncmp(line, "</office:meta>", sizeof("</office:meta>") - 1) == 0) {
-		    in_meta = false;
-		    map<string, const char *>::const_iterator i;
-		    for (i = meta.begin(); i != meta.end(); ++i) {
-			const char * tag = i->first.c_str();
-			write_xml_tag(out, tag, i->second);
-		    }
-		    meta.clear();
-		} else if (line[0] == '<') {
-		    map<string, const char *>::iterator i;
-		    for (i = meta.begin(); i != meta.end(); ++i) {
-			const char * tag = i->first.c_str();
-			if (strncmp(line + 1, tag, i->first.size()) == 0 &&
-			    line[1 + i->first.size()] == '>') {
-			    write_xml_tag(out, tag, i->second);
-			    meta.erase(i);
-			    if ((c = getdelim(&line, &len, '>', f)) == -1) break;
-			    goto next;
-			}
-		    }
-		}
-	    } else {
-		if (strncmp(line, "<office:meta>", sizeof("<office:meta>") - 1) == 0) {
-		    in_meta = true;
-		}
-	    }
-	    fwrite(line, c, 1, out);
-next:;
-	}
-
-	if (fclose(out) < 0) {
-	    cerr << program << ": fclose() failed (" << strerror(errno) << ")" << endl;
-	    _Exit(1);
-	}
-
-	if (pclose(f) < 0) {
-	    cerr << program << ": pclose() failed (" << strerror(errno) << ")" << endl;
-	    _Exit(1);
-	}
-
-	int r = system("zip tmp.odt meta.xml");
-	unlink("meta.xml");
-	if (!WIFEXITED(r) || WEXITSTATUS(r) != 0) {
-	    cerr << program << ": failed to run zip command" << endl;
-	    _Exit(1);
-	}
-
-	if (fchdir(cwd_fd) < 0) {
-	    cerr << program << ": fchdir() failed (" << strerror(errno) << ")" << endl;
-	    _Exit(1);
-	}
-	rc = convert(handle, false, odt.c_str(), output);
-	unlink(odt.c_str());
+    bool in_meta = false;
+    while ((c = getdelim(&line, &len, '>', f)) != -1) {
+      if (in_meta) {
+        if (strncmp(line, "</office:meta>", sizeof("</office:meta>") - 1) ==
+            0) {
+          in_meta = false;
+          map<string, const char *>::const_iterator i;
+          for (i = meta.begin(); i != meta.end(); ++i) {
+            const char *tag = i->first.c_str();
+            write_xml_tag(out, tag, i->second);
+          }
+          meta.clear();
+        } else if (line[0] == '<') {
+          map<string, const char *>::iterator i;
+          for (i = meta.begin(); i != meta.end(); ++i) {
+            const char *tag = i->first.c_str();
+            if (strncmp(line + 1, tag, i->first.size()) == 0 &&
+                line[1 + i->first.size()] == '>') {
+              write_xml_tag(out, tag, i->second);
+              meta.erase(i);
+              if ((c = getdelim(&line, &len, '>', f)) == -1)
+                break;
+              goto next;
+            }
+          }
+        }
+      } else {
+        if (strncmp(line, "<office:meta>", sizeof("<office:meta>") - 1) == 0) {
+          in_meta = true;
+        }
+      }
+      fwrite(line, c, 1, out);
+    next:;
     }
-    convert_cleanup(handle);
 
-    // Avoid segfault from LibreOffice by terminating swiftly.
-    _Exit(rc);
+    if (fclose(out) < 0) {
+      cerr << program << ": fclose() failed (" << strerror(errno) << ")"
+           << endl;
+      _Exit(1);
+    }
+
+    if (pclose(f) < 0) {
+      cerr << program << ": pclose() failed (" << strerror(errno) << ")"
+           << endl;
+      _Exit(1);
+    }
+
+    int r = system("zip tmp.odt meta.xml");
+    unlink("meta.xml");
+    if (!WIFEXITED(r) || WEXITSTATUS(r) != 0) {
+      cerr << program << ": failed to run zip command" << endl;
+      _Exit(1);
+    }
+
+    if (fchdir(cwd_fd) < 0) {
+      cerr << program << ": fchdir() failed (" << strerror(errno) << ")"
+           << endl;
+      _Exit(1);
+    }
+    rc = convert(handle, false, odt.c_str(), output);
+    unlink(odt.c_str());
+  }
+  convert_cleanup(handle);
+
+  // Avoid segfault from LibreOffice by terminating swiftly.
+  _Exit(rc);
 }

--- a/lloconv.cc
+++ b/lloconv.cc
@@ -16,97 +16,94 @@
 
 using namespace std;
 
-static void
-usage()
-{
-    cerr << "Usage: " << program << " [-u] [-f OUTPUT_FORMAT] [-o OPTIONS] INPUT_FILE OUTPUT_FILE\n\n";
-    cerr << "  -u  INPUT_FILE is a URL\n";
-    cerr << "Specifying options requires LibreOffice >= 4.3.0rc1\n\n";
-    cerr << "Known values for OUTPUT_FORMAT include:\n";
-    cerr << "  For text documents: doc docx fodt html odt ott pdf txt xhtml\n\n";
-    cerr << "Known OPTIONS include: SkipImages\n";
-    cerr << flush;
+static void usage() {
+  cerr << "Usage: " << program
+       << " [-u] [-f OUTPUT_FORMAT] [-o OPTIONS] INPUT_FILE OUTPUT_FILE\n\n";
+  cerr << "  -u  INPUT_FILE is a URL\n";
+  cerr << "Specifying options requires LibreOffice >= 4.3.0rc1\n\n";
+  cerr << "Known values for OUTPUT_FORMAT include:\n";
+  cerr << "  For text documents: doc docx fodt html odt ott pdf txt xhtml\n\n";
+  cerr << "Known OPTIONS include: SkipImages\n";
+  cerr << flush;
 }
 
-int
-main(int argc, char **argv)
-{
-    program = argv[0];
+int main(int argc, char **argv) {
+  program = argv[0];
 
-    if (argc < 3) {
-	usage();
-	_Exit(EX_USAGE);
+  if (argc < 3) {
+    usage();
+    _Exit(EX_USAGE);
+  }
+
+  const char *format = NULL;
+  const char *options = NULL;
+  bool url = false;
+  // FIXME: Use getopt() or something.
+  ++argv;
+  --argc;
+  while (argv[0] && argv[0][0] == '-') {
+    switch (argv[0][1]) {
+    case '-':
+      if (argv[0][2] == '\0') {
+        // End of options.
+        ++argv;
+        --argc;
+        goto last_option;
+      }
+      break;
+    case 'f':
+      if (argv[0][2]) {
+        format = argv[0] + 2;
+        ++argv;
+        --argc;
+      } else {
+        format = argv[1];
+        argv += 2;
+        argc -= 2;
+      }
+      continue;
+    case 'o':
+      if (argv[0][2]) {
+        options = argv[0] + 2;
+        ++argv;
+        --argc;
+      } else {
+        options = argv[1];
+        argv += 2;
+        argc -= 2;
+      }
+      continue;
+    case 'u':
+      if (argv[0][2] != '\0') {
+        break;
+      }
+      url = true;
+      ++argv;
+      --argc;
+      continue;
     }
 
-    const char * format = NULL;
-    const char * options = NULL;
-    bool url = false;
-    // FIXME: Use getopt() or something.
-    ++argv;
-    --argc;
-    while (argv[0] && argv[0][0] == '-') {
-	switch (argv[0][1]) {
-	    case '-':
-		if (argv[0][2] == '\0') {
-		    // End of options.
-		    ++argv;
-		    --argc;
-		    goto last_option;
-		}
-		break;
-	    case 'f':
-		if (argv[0][2]) {
-		    format = argv[0] + 2;
-		    ++argv;
-		    --argc;
-		} else {
-		    format = argv[1];
-		    argv += 2;
-		    argc -= 2;
-		}
-		continue;
-	    case 'o':
-		if (argv[0][2]) {
-		    options = argv[0] + 2;
-		    ++argv;
-		    --argc;
-		} else {
-		    options = argv[1];
-		    argv += 2;
-		    argc -= 2;
-		}
-		continue;
-	    case 'u':
-		if (argv[0][2] != '\0') {
-		    break;
-		}
-		url = true;
-		++argv;
-		--argc;
-		continue;
-	}
-
-	cerr << "Option '" << argv[0] << "' unknown\n\n";
-	argc = -1;
-	break;
-    }
+    cerr << "Option '" << argv[0] << "' unknown\n\n";
+    argc = -1;
+    break;
+  }
 last_option:
 
-    if (argc != 2) {
-	usage();
-	_Exit(EX_USAGE);
-    }
+  if (argc != 2) {
+    usage();
+    _Exit(EX_USAGE);
+  }
 
-    const char * input = argv[0];
-    const char * output = argv[1];
+  const char *input = argv[0];
+  const char *output = argv[1];
 
-    void * handle = convert_init();
-    if (!handle) {
-	_Exit(EX_UNAVAILABLE);
-    }
-    int rc = convert(handle, url, input, output, format, options);
-    convert_cleanup(handle);
+  void *handle = convert_init();
+  if (!handle) {
+    _Exit(EX_UNAVAILABLE);
+  }
+  int rc = convert(handle, url, input, output, format, options);
+  convert_cleanup(handle);
 
-    // Avoid segfault from LibreOffice by terminating swiftly.
-    _Exit(rc);
+  // Avoid segfault from LibreOffice by terminating swiftly.
+  _Exit(rc);
 }

--- a/urlencode.cc
+++ b/urlencode.cc
@@ -30,19 +30,17 @@
 
 using namespace std;
 
-void
-url_encode_(string & res, const char * p, size_t len, const char * safe)
-{
-    while (len--) {
-	unsigned char ch = *p++;
-	if (isalnum(ch) || strchr(safe, ch)) {
-	    // Unreserved by RFC3986.
-	    res += ch;
-	} else {
-	    // RFC3986 says we "should" encode as upper case hex digits.
-	    res += '%';
-	    res += "0123456789ABCDEF"[ch >> 4];
-	    res += "0123456789ABCDEF"[ch & 0x0f];
-	}
+void url_encode_(string &res, const char *p, size_t len, const char *safe) {
+  while (len--) {
+    unsigned char ch = *p++;
+    if (isalnum(ch) || strchr(safe, ch)) {
+      // Unreserved by RFC3986.
+      res += ch;
+    } else {
+      // RFC3986 says we "should" encode as upper case hex digits.
+      res += '%';
+      res += "0123456789ABCDEF"[ch >> 4];
+      res += "0123456789ABCDEF"[ch & 0x0f];
     }
+  }
 }

--- a/urlencode.h
+++ b/urlencode.h
@@ -28,34 +28,24 @@
 #include <cstring>
 #include <string>
 
-void url_encode_(std::string & res,
-		 const char * p, size_t len,
-		 const char * safe);
+void url_encode_(std::string &res, const char *p, size_t len, const char *safe);
 
-inline void
-url_encode(std::string & res, const std::string &str)
-{
-    url_encode_(res, str.data(), str.size(), "-._~");
+inline void url_encode(std::string &res, const std::string &str) {
+  url_encode_(res, str.data(), str.size(), "-._~");
 }
 
-inline void
-url_encode(std::string & res, const char * p)
-{
-    url_encode_(res, p, std::strlen(p), "-._~");
+inline void url_encode(std::string &res, const char *p) {
+  url_encode_(res, p, std::strlen(p), "-._~");
 }
 
 /// Append a path, url encoding the segments, but not the '/' between them.
-inline void
-url_encode_path(std::string & res, const std::string &str)
-{
-    url_encode_(res, str.data(), str.size(), "/-._~");
+inline void url_encode_path(std::string &res, const std::string &str) {
+  url_encode_(res, str.data(), str.size(), "/-._~");
 }
 
 /// Append a path, url encoding the segments, but not the '/' between them.
-inline void
-url_encode_path(std::string & res, const char * p)
-{
-    url_encode_(res, p, std::strlen(p), "/-._~");
+inline void url_encode_path(std::string &res, const char *p) {
+  url_encode_(res, p, std::strlen(p), "/-._~");
 }
 
 #endif // OMEGA_INCLUDED_URLENCODE_H


### PR DESCRIPTION
Apply default style of `clang-format` version 5.0.1.

```sh
find -type f \( -iname '*.cc' -or -iname '*.h' \) -print -exec clang-format -i '{}' +
```

I advise to add some sort of CI that gates new commits on being formatted as expected.