### PR TITLE
Allow building against LOK headers outside /usr/include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 CC = gcc
 CXX = g++
 
+INCLUDES = -I.
+ifneq ($(LO_INCLUDE_PATH),)
+INCLUDES += -I$(LO_INCLUDE_PATH)
+endif
+
 all: lloconv inject-meta
 
 lloconv: lloconv.o convert.o urlencode.o
@@ -11,20 +16,20 @@ inject-meta: inject-meta.o convert.o urlencode.o
 
 lloconv.o: lloconv.cc \
     convert.h
-	$(CXX) -I. -c -W -Wall -O2 -g lloconv.cc -o lloconv.o
+	$(CXX) $(INCLUDES) -c -W -Wall -O2 -g lloconv.cc -o lloconv.o
 
 inject-meta.o: inject-meta.cc \
     convert.h
-	$(CXX) -I. -c -W -Wall -O2 -g inject-meta.cc -o inject-meta.o
+	$(CXX) $(INCLUDES) -c -W -Wall -O2 -g inject-meta.cc -o inject-meta.o
 
 urlencode.o: urlencode.cc \
     urlencode.h
-	$(CXX) -I. -c -W -Wall -O2 -g urlencode.cc -o urlencode.o
+	$(CXX) $(INCLUDES) -c -W -Wall -O2 -g urlencode.cc -o urlencode.o
 
 convert.o: convert.cc \
     convert.h \
     urlencode.h
-	$(CXX) -I. -c -W -Wall -O2 -g convert.cc -o convert.o
+	$(CXX) $(INCLUDES) -c -W -Wall -O2 -g convert.cc -o convert.o
 
 clean:
 	rm -f lloconv inject-meta *.o


### PR DESCRIPTION
Example:

make LO_INCLUDE_PATH="$HOME/git/libreoffice/master/include"

This allows building on a system where $HOME/git/libreoffice/master is a
git checkout and /usr/include has no LOK headers.